### PR TITLE
Enhancement: any interface can be use as PacketFence management interface

### DIFF
--- a/packetfence/roles/packetfence_common/tasks/main.yml
+++ b/packetfence/roles/packetfence_common/tasks/main.yml
@@ -6,25 +6,23 @@
 - name: include distribution specific tasks
   include_tasks: "{{ ansible_os_family|lower }}.yml"
 
-- name: ensure iproute package is installed for next task
+- name: ensure iproute package is installed to get network informations
   package:
     name: "{{ packetfence_common__iproute_pkg }}"
     state: present
   register: packetfence_common__register_pkg_iproute
 
-- name: recall setup module to refresh facts
+- name: recall setup module to refresh ansible_default_ipv4 facts
   setup:
     filter: ansible_default_ipv4*
+  when: packetfence_common__register_pkg_iproute is changed
+
+- name: recall setup module to refresh ansible_eth facts
+  setup:
+    filter: ansible_eth*
   when: packetfence_common__register_pkg_iproute is changed
 
 - name: ensure python-passlib package is installed for htpasswd sources
   package:
     name: "{{ packetfence_common__passlib_pkg }}"
     state: present
-    
-- name: ensure management IP is in /etc/hosts
-  lineinfile:
-    path: /etc/hosts
-    regexp: '^{{ ansible_default_ipv4.address }} {{ ansible_hostname }} {{ ansible_nodename }}'
-    line: '{{ ansible_default_ipv4.address }} {{ ansible_hostname }} {{ ansible_nodename }}'
-  when: ansible_virtualization_type != 'docker'

--- a/packetfence/roles/packetfence_install/tasks/api_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/api_config.yml
@@ -1,7 +1,7 @@
 ---
 - name: POST {{ packetfence_install__api_login }}
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_login }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_login }}"
     method: POST
     follow_redirects: safe
     validate_certs: no
@@ -17,7 +17,7 @@
 # loop on {{ packetfence_install__api_calls }} vars
 - name: configure pf through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ item['route'] }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ item['route'] }}"
     method: "{{ item['method'] }}"
     follow_redirects: safe
     validate_certs: no

--- a/packetfence/roles/packetfence_install/tasks/api_sources.yml
+++ b/packetfence/roles/packetfence_install/tasks/api_sources.yml
@@ -15,7 +15,7 @@
 # don't fail if it already exist
 - name: create {{ source['id'] }} source through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_config_endpoints['sources'] }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_config_endpoints['sources'] }}"
     method: POST
     follow_redirects: safe
     validate_certs: no
@@ -33,7 +33,7 @@
 # update source only if it was already created (409 from previous task)
 - name: update {{ source['id'] }} source through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_config_endpoints['source'] }}/{{ source['id'] }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_config_endpoints['source'] }}/{{ source['id'] }}"
     method: PATCH
     follow_redirects: safe
     validate_certs: no

--- a/packetfence/roles/packetfence_install/tasks/api_users.yml
+++ b/packetfence/roles/packetfence_install/tasks/api_users.yml
@@ -6,7 +6,7 @@
 # don't fail if it already exist
 - name: create {{ user['body_user']['pid'] }} user through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_users }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_users }}"
     method: POST
     follow_redirects: safe
     validate_certs: no
@@ -24,7 +24,7 @@
 # update user only if it was already created (409 from previous task)
 - name: update {{ user['body_user']['pid'] }} user through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_user }}/{{ user['body_user']['pid'] }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_user }}/{{ user['body_user']['pid'] }}"
     method: PATCH
     follow_redirects: safe
     validate_certs: no
@@ -43,7 +43,7 @@
 # don't fail if it already exist
 - name: create password for {{ user['body_user']['pid'] }} user through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_user }}/{{ user['body_user']['pid'] }}/password"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_user }}/{{ user['body_user']['pid'] }}/password"
     method: POST
     follow_redirects: safe
     validate_certs: no
@@ -61,7 +61,7 @@
 # update password entry only if it was already created (409 from previous task)
 - name: update password for {{ user['body_user']['pid'] }} user through API calls
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_user }}/{{ user['body_user']['pid'] }}/password"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__api_port }}/{{ packetfence_install__api_user }}/{{ user['body_user']['pid'] }}/password"
     method: PATCH
     follow_redirects: safe
     validate_certs: no

--- a/packetfence/roles/packetfence_install/tasks/configurator.yml
+++ b/packetfence/roles/packetfence_install/tasks/configurator.yml
@@ -96,7 +96,7 @@
 
 - name: check end of configurator
   uri:
-    url: "https://{{ ansible_default_ipv4['address'] }}:{{ packetfence_install__webadmin_port }}"
+    url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__webadmin_port }}"
     return_content: yes
     follow_redirects: safe
     validate_certs: no

--- a/packetfence/roles/packetfence_install/tasks/main.yml
+++ b/packetfence/roles/packetfence_install/tasks/main.yml
@@ -7,6 +7,13 @@
 - name: include distribution specific tasks
   include_tasks: "{{ ansible_os_family|lower }}.yml"
 
+- name: ensure management IP is in /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    regexp: '^{{ packetfence_install__mgmt_interface['ip'] }} {{ ansible_hostname }} {{ ansible_nodename }}'
+    line: '{{ packetfence_install__mgmt_interface['ip'] }} {{ ansible_hostname }} {{ ansible_nodename }}'
+  when: ansible_virtualization_type != 'docker'
+
 - name: include utils tasks
   include_tasks: utils.yml
   tags: utils

--- a/packetfence/roles/packetfence_install/tasks/main.yml
+++ b/packetfence/roles/packetfence_install/tasks/main.yml
@@ -10,8 +10,8 @@
 - name: ensure management IP is in /etc/hosts
   lineinfile:
     path: /etc/hosts
-    regexp: '^{{ packetfence_install__mgmt_interface['ip'] }} {{ ansible_hostname }} {{ ansible_nodename }}'
-    line: '{{ packetfence_install__mgmt_interface['ip'] }} {{ ansible_hostname }} {{ ansible_nodename }}'
+    regexp: "^{{ packetfence_install__mgmt_interface['ip'] }} {{ ansible_hostname }} {{ ansible_nodename }}"
+    line: "{{ packetfence_install__mgmt_interface['ip'] }} {{ ansible_hostname }} {{ ansible_nodename }}"
   when: ansible_virtualization_type != 'docker'
 
 - name: include utils tasks


### PR DESCRIPTION
I made this PR to have a working setup with Vagrant when PacketFence is installed.

After initial installation of PacketFence, `packetfence-iptables` will only allow SSH to `mgmt_interface`.