### PR TITLE
[packetfence_install] Install latest packages if devel repos enabled

### DIFF
--- a/packetfence/roles/packetfence_install/defaults/main.yml
+++ b/packetfence/roles/packetfence_install/defaults/main.yml
@@ -22,6 +22,12 @@ packetfence_install__deb_packages:
 
 packetfence_install__shell_rc_file: /root/.bashrc
 
+### devel repos
+packetfence_install__devel_repo: "{{ True
+                                     if (packetfence_install_centos['repo'] == 'packetfence-devel' or
+                                         'packetfence-devel' in packetfence_install__deb['repos'])
+                                     else False }}"
+
 ### database
 packetfence_install__database_db: pf
 packetfence_install__database_root_user: root

--- a/packetfence/roles/packetfence_install/defaults/main.yml
+++ b/packetfence/roles/packetfence_install/defaults/main.yml
@@ -24,7 +24,7 @@ packetfence_install__shell_rc_file: /root/.bashrc
 
 ### devel repos
 packetfence_install__devel_repo: "{{ True
-                                     if (packetfence_install_centos['repo'] == 'packetfence-devel' or
+                                     if (packetfence_install__centos['repo'] == 'packetfence-devel' or
                                          'packetfence-devel' in packetfence_install__deb['repos'])
                                      else False }}"
 

--- a/packetfence/roles/packetfence_install/tasks/debian.yml
+++ b/packetfence/roles/packetfence_install/tasks/debian.yml
@@ -19,5 +19,7 @@
 - name: Install PacketFence from the repo
   apt:
     name: "{{ packetfence_install__deb_packages }}"
-    state: present
+    state: '{{ "latest"
+               if packetfence_install__devel_repo|bool
+               else "present" }}'
   register: packetfence_install__register_packages

--- a/packetfence/roles/packetfence_install/tasks/redhat.yml
+++ b/packetfence/roles/packetfence_install/tasks/redhat.yml
@@ -30,6 +30,8 @@
   yum:
     name: "{{ packetfence_install__centos_packages }}"
     enablerepo: "{{ packetfence_install__centos['repo'] }}"
-    state: present
+    state: '{{ "latest"
+               if packetfence_install__devel_repo|bool
+               else "present" }}'
     update_cache: yes
   register: packetfence_install__register_packages


### PR DESCRIPTION
Always install latest packetfence packages if devel repos have been configured in Ansible inventory.

I will use this PR to install nightly builds on machines started by Vagrant.