### PR TITLE
Configure Fingerbank API key and minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configure Fingerbank API key through inventory
+- Hide password of `pf` user in DB
+
+### Changed
+
+### Removed
+- Installation of `pfsql` binary in `/usr/local/pf/bin`
+
 ## [0.3.0] - 2019-11-25
 
 ### Added

--- a/packetfence/roles/packetfence_install/defaults/main.yml
+++ b/packetfence/roles/packetfence_install/defaults/main.yml
@@ -52,6 +52,12 @@ packetfence_install__mgmt_interface:
   mask: "{{ ansible_default_ipv4['netmask'] }}"
   type: management
 
+
+# fingerbank settings
+packetfence_install__fingerbank_setting:
+  upstream:
+    api_key: ''
+
 ### users
 packetfence_install__admin_user:
   pid: admin
@@ -61,3 +67,4 @@ packetfence_install__admin_user:
 packetfence_install__admin_credentials:
   username: "{{ packetfence_install__admin_user['pid'] }}"
   password: "{{ packetfence_install__admin_user['password'] }}"
+

--- a/packetfence/roles/packetfence_install/files/pfsql
+++ b/packetfence/roles/packetfence_install/files/pfsql
@@ -1,6 +1,0 @@
-#!/bin/bash
-# This script will connect you to DB use by pf app
-mysql -u $(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{user}') \
-      -p$(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{pass}') -h \
-      $(perl -I/usr/local/pf/lib -Mpf::db -e 'print $pf::db::DB_Config->{host}') \
-      pf

--- a/packetfence/roles/packetfence_install/handlers/main.yml
+++ b/packetfence/roles/packetfence_install/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart packetfence-fingerbank-collector service
+  service:
+    name: packetfence-fingerbank-collector
+    state: restarted
+    enabled: True

--- a/packetfence/roles/packetfence_install/tasks/db.yml
+++ b/packetfence/roles/packetfence_install/tasks/db.yml
@@ -79,4 +79,4 @@
   loop: "{{ packetfence_install__database_users }}"
   # avoid display password for each item of the loop
   loop_control:
-    label: "{{ item['name'] }} - {{ item['host'] }} - {{ item['priv'] }}"
+    label: "{{ host: {{ item['host'] }}, name: item['name'] }}, priv: {{ item['priv'] }}"

--- a/packetfence/roles/packetfence_install/tasks/db.yml
+++ b/packetfence/roles/packetfence_install/tasks/db.yml
@@ -77,3 +77,6 @@
     host: "{{ item.host }}"
     state: present
   loop: "{{ packetfence_install__database_users }}"
+  # avoid display password for each item of the loop
+  loop_control:
+    label: "{{ item['name'] }} - {{ item['host'] }} - {{ item['priv'] }}"

--- a/packetfence/roles/packetfence_install/tasks/minimal_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/minimal_config.yml
@@ -10,7 +10,7 @@
     owner: "{{ packetfence_install__user }}"
     group: "{{ packetfence_install__group }}"
     no_extra_spaces: yes
-  register: packetfence_install__register_configurator_db_pwd
+  register: packetfence_install__register_mininal_config_db_pwd
 
 - name: set packetfence password in db in pfconfig.conf
   ini_file:
@@ -23,7 +23,7 @@
     owner: "{{ packetfence_install__user }}"
     group: "{{ packetfence_install__group }}"
     no_extra_spaces: yes
-  register: packetfence_install__register_configurator_pfconfig_pwd
+  register: packetfence_install__register_mininal_config_pfconfig_pwd
   
 - name: define mgmt interface in pf.conf
   ini_file:
@@ -62,4 +62,4 @@
   service:
     name: packetfence-config
     state: restarted
-  when: (packetfence_install__register_configurator_db_pwd or packetfence_install__register_configurator_pfconfig_pwd) is changed
+  when: (packetfence_install__register_mininal_config_db_pwd or packetfence_install__register_mininal_config_pfconfig_pwd) is changed

--- a/packetfence/roles/packetfence_install/tasks/minimal_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/minimal_config.yml
@@ -42,7 +42,21 @@
       value: "{{ packetfence_install__mgmt_interface['mask'] }}"
     - name: type
       value: "{{ packetfence_install__mgmt_interface['type'] }}"
-    
+
+- name: configure fingerbank API key
+  ini_file:
+    path: "{{ packetfence_install__fingerbank_conf_dir }}/fingerbank.conf"
+    section: 'upstream'
+    option: 'api_key'
+    value: "{{ packetfence_install__fingerbank_setting['upstream']['api_key'] }}"
+    mode: 0660
+    owner: "{{ packetfence_install__fingerbank_user }}"
+    group: "{{ packetfence_install__fingerbank_group }}"
+    no_extra_spaces: yes
+  when: packetfence_install__fingerbank_setting['upstream']['api_key']
+  notify: restart packetfence-fingerbank-collector service
+  no_log: True
+
 # to take new DB password into account
 - name: restart packetfence-config service
   service:

--- a/packetfence/roles/packetfence_install/tasks/post_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/post_config.yml
@@ -10,10 +10,10 @@
       - "/{{ packetfence_install__api_user }}/{{ packetfence_install__admin_user['pid'] }}/password"
       - "-c"
       - "{{ packetfence_install__admin_user | to_json }}"
-  register: packetfence_install__register_configurator_admin_pwd
+  register: packetfence_install__register_post_config_admin_pwd
   # failed when status is different from 200
   # pfperl-api always return rc=0
-  failed_when: (packetfence_install__register_configurator_admin_pwd['stdout'] | from_json ).status != 200
+  failed_when: (packetfence_install__register_post_config_admin_pwd['stdout'] | from_json ).status != 200
 
 - name: fix permissions on pf files
   command: "{{ packetfence_install__pfcmd }} fixpermissions"
@@ -49,7 +49,7 @@
     return_content: yes
     follow_redirects: safe
     validate_certs: no
-  register: packetfence_install__register_configurator_homepage
-  until: "'Administrator - PacketFence' in packetfence_install__register_configurator_homepage['content']"
+  register: packetfence_install__register_post_config_homepage
+  until: "'Administrator - PacketFence' in packetfence_install__register_post_config_homepage['content']"
   retries: 6
   delay: 10

--- a/packetfence/roles/packetfence_install/tasks/post_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/post_config.yml
@@ -1,4 +1,4 @@
----  
+---
 - name: update admin password in db through pfperl-api
   command:
   args:

--- a/packetfence/roles/packetfence_install/tasks/utils.yml
+++ b/packetfence/roles/packetfence_install/tasks/utils.yml
@@ -24,12 +24,4 @@
       alias authdbg='raddebug -d /usr/local/pf/raddb -f /usr/local/pf/var/run/radiusd.sock -t 300'
       alias acctdbg='raddebug -d /usr/local/pf/raddb -f /usr/local/pf/var/run/radiusd-acct.sock -t 300'
       alias radmin='radmin -d /usr/local/pf/raddb -f /usr/local/pf/var/run/radiusd.sock'
-
-- name: install pfsql in {{ packetfence_install__bin_dir }}
-  copy:
-    src: pfsql
-    dest: "{{ packetfence_install__bin_dir }}/pfsql"
-    mode: 0766
-    owner: "{{ packetfence_install__user }}"
-    group: "{{ packetfence_install__group }}"
     

--- a/packetfence/roles/packetfence_install/vars/main.yml
+++ b/packetfence/roles/packetfence_install/vars/main.yml
@@ -7,6 +7,10 @@ packetfence_install__bin_dir: "{{ packetfence_install__root_dir }}/bin"
 packetfence_install__sbin_dir: "{{ packetfence_install__root_dir }}/sbin"
 packetfence_install__db_dir: "{{ packetfence_install__root_dir }}/db"
 
+# fingerbank
+packetfence_install__fingerbank_dir: /usr/local/fingerbank
+packetfence_install__fingerbank_conf_dir: '{{ packetfence_install__fingerbank_dir }}/conf'
+
 ## files
 packetfence_install__currently_at_file: "{{ packetfence_install__conf_dir }}/currently-at"
 
@@ -17,6 +21,9 @@ packetfence_install__perlapi_cmd: "{{ packetfence_install__sbin_dir }}/pfperl-ap
 ## users
 packetfence_install__user: pf
 packetfence_install__group: pf
+packetfence_install__fingerbank_user: fingerbank
+packetfence_install__fingerbank_group: fingerbank
+
 
 ## ports
 packetfence_install__webadmin_port: 1443
@@ -52,5 +59,7 @@ packetfence_install__api_config_endpoints:
 
 packetfence_install__api_login: "{{ packetfence_install__api_base_path }}/login"
 packetfence_install__api_nodes: "{{ packetfence_install__api_base_path }}/nodes"
+
+# users
 packetfence_install__api_user: "{{ packetfence_install__api_base_path }}/user"
 packetfence_install__api_users: "{{ packetfence_install__api_base_path }}/users"


### PR DESCRIPTION
- Configure Fingerbank API key through inventory (necessary for PF Perl unit tests)
- Remove installation of `pfsql` binary to avoid issue in PF Perl unit tests
- Avoid display password for `pf` user in

`no_log` directive has been used to avoid display of Fingerbank API key when running play with verbose.