### PR TITLE
Disable configurator using new setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Disable configurator using new setting (#17)
 
 ## [0.4.0] - 2019-12-23
 

--- a/packetfence/galaxy.yml
+++ b/packetfence/galaxy.yml
@@ -4,7 +4,7 @@
 
 namespace: "inverse_inc"
 name: "packetfence"
-version: "0.4.0"
+version: "0.5.0-1"
 description: "Collections of Ansible roles to manage PacketFence installations."
 
 authors:

--- a/packetfence/roles/packetfence_install/README.md
+++ b/packetfence/roles/packetfence_install/README.md
@@ -26,6 +26,7 @@ Role Variables
 | `packetfence_install__database_pass`           | `secret`                                                                                       | Default database password for first database users                      |
 | `packetfence_install__database_users`          | See `defaults/main.yml`                                                                        | Dict of database users with their privileges                            |
 | `packetfence_install__database_socket`         | Distribution specific, see `vars/` dir                                                         | Local socket to use                                                     |
+| `packetfence_install__configurator_status`     | `disabled`                                                                                     | Status of configurator setting                                          |
 | `packetfence_install__mgmt_interface`          | `ansible_default_ipv4` settings + `type: management`                                           | Dict with settings for management interface settings                    |
 | `packetfence_install__admin_user`              | `{pid: admin, password: secret }`                                                              | Dict with username and password for default admin user                  |
 | `packetfence_install__admin_credentials`       | Credentials of default admin user                                                              | Dict with username and password use to authenticate against API         |

--- a/packetfence/roles/packetfence_install/defaults/main.yml
+++ b/packetfence/roles/packetfence_install/defaults/main.yml
@@ -45,6 +45,10 @@ packetfence_install__database_users:
     host: "%"
 
 ### configurator
+# default value is different from PF defaults
+# but we assume that when we use Ansible, we don't use configurator
+packetfence_install__configurator_status: 'disabled'
+
 # interfaces
 packetfence_install__mgmt_interface:
   id: "{{ ansible_default_ipv4['interface'] }}"

--- a/packetfence/roles/packetfence_install/tasks/minimal_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/minimal_config.yml
@@ -57,6 +57,18 @@
   notify: restart packetfence-fingerbank-collector service
   no_log: True
 
+- name: disable configurator in pf.conf
+  ini_file:
+    path: "{{ packetfence_install__conf_dir }}/pf.conf"
+    section: advanced
+    option: configurator
+    value: "{{ packetfence_install__configurator_status }}"
+    state: present
+    mode: 0664
+    owner: "{{ packetfence_install__user }}"
+    group: "{{ packetfence_install__group }}"
+    no_extra_spaces: yes
+
 # to take new DB password into account
 - name: restart packetfence-config service
   service:

--- a/packetfence/roles/packetfence_install/tasks/post_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/post_config.yml
@@ -33,19 +33,6 @@
   command: "{{ packetfence_install__pfcmd }} service pf restart"
   when: packetfence_install__register_packages is changed
 
-- name: disable configurator in pf.conf
-  ini_file:
-    path: "{{ packetfence_install__conf_dir }}/pf.conf"
-    section: advanced
-    option: configurator
-    value: "{{ packetfence_install__configurator_status }}"
-    state: present
-    mode: 0664
-    owner: "{{ packetfence_install__user }}"
-    group: "{{ packetfence_install__group }}"
-    no_extra_spaces: yes
-  register: packetfence_install__register_post_config_configurator
-
 - name: check end of configurator
   uri:
     url: "https://{{ packetfence_install__mgmt_interface['ip'] }}:{{ packetfence_install__webadmin_port }}"

--- a/packetfence/roles/packetfence_install/tasks/post_config.yml
+++ b/packetfence/roles/packetfence_install/tasks/post_config.yml
@@ -33,15 +33,18 @@
   command: "{{ packetfence_install__pfcmd }} service pf restart"
   when: packetfence_install__register_packages is changed
 
-# copy pf-release to currently-at
-- name: ensure currently-at file is set
-  copy:
-    src: "{{ packetfence_install__conf_dir }}/pf-release"
-    remote_src: yes
-    dest: "{{ packetfence_install__conf_dir }}/currently-at"
+- name: disable configurator in pf.conf
+  ini_file:
+    path: "{{ packetfence_install__conf_dir }}/pf.conf"
+    section: advanced
+    option: configurator
+    value: "{{ packetfence_install__configurator_status }}"
+    state: present
+    mode: 0664
     owner: "{{ packetfence_install__user }}"
     group: "{{ packetfence_install__group }}"
-    mode: preserve
+    no_extra_spaces: yes
+  register: packetfence_install__register_post_config_configurator
 
 - name: check end of configurator
   uri:


### PR DESCRIPTION
Use `configurator=disabled` in `pf.conf` to disable configurator.