### PR TITLE
Improve Ansible support to manage PacketFence instances only with Ansible (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use new repository layout
 
+## [1.1.1] - 2021-06-24
+
+### Changed
+- Don't display content of config files
+- Always restart packetfence-config service when a change is detected
+
 ## [1.1.0] - 2020-09-22
 
 ### Changed
@@ -70,7 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update defaults to reflect packaging changes introduced by PacketFence
   v9.2.0 (#13)
 
-[Unreleased]: https://github.com/inverse-inc/ansible-packetfence/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/inverse-inc/ansible-packetfence/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/inverse-inc/ansible-packetfence/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/inverse-inc/ansible-packetfence/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/inverse-inc/ansible-packetfence/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/inverse-inc/ansible-packetfence/compare/v1.0.1...v1.0.2

--- a/packetfence/meta/runtime.yml
+++ b/packetfence/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.10"

--- a/packetfence/roles/packetfence_install/tasks/config.yml
+++ b/packetfence/roles/packetfence_install/tasks/config.yml
@@ -8,9 +8,16 @@
     group: "{{ packetfence_install__group }}"
   loop: '{{ packetfence_install__configuration }}'
   register: packetfence_install__register_config_files
+  no_log: True
 
 - name: Reload config
   command: "{{ packetfence_install__pfcmd }} configreload hard"
+  when: packetfence_install__register_config_files is changed
+
+- name: Restart packetfence-config service
+  service:
+    name: packetfence-config
+    state: restarted
   when: packetfence_install__register_config_files is changed
     
 - name: configure fingerbank API key


### PR DESCRIPTION
Due to conflicts with master branch (related to changes that need to wait PF v11 release), I propose following plan:
1. review
2. if everything is ok:
   1. build collection on that branch
   2. upload to Ansible Galaxy
   3. tag v1.1.1 on that branch
3. merge this branch on devel and solve conflicts